### PR TITLE
Fix mobile menu z-index

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -29,7 +29,7 @@
   </header>
 
   <!-- MENÚ móvil -->
-  <div id="mobile-menu" class="hidden fixed inset-0 bg-opacity-60 z-300 bg-(--bg-sidebar)">
+  <div id="mobile-menu" class="hidden fixed inset-0 bg-opacity-60 z-[300] bg-(--bg-sidebar)">
     <div class="w-full h-full p-4 overflow-auto">
       <button id="mobile-menu-close" class="mb-4 p-2 focus:outline-none text-(--text-color)">✕</button>
       <nav>


### PR DESCRIPTION
## Summary
- correct Tailwind z-index class for mobile menu overlay

## Testing
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843d5ebdefc832591b730195c9e2f5e